### PR TITLE
Clean up warnings

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -2,7 +2,7 @@ use crate::Updateable;
 
 #[derive(Default)]
 pub struct Circuit {
-    updater: Vec<Box<Updateable>>,
+    updater: Vec<Box<dyn Updateable>>,
 }
 
 impl Circuit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(nll, try_from, vec_remove_item)]
+#![feature(vec_remove_item)]
 #![warn(missing_docs)]
 
 //! Logical is a digital network simulator. It is named after the german word "Logical" which


### PR DESCRIPTION
Both changes triggered warnings on current versions of rust.